### PR TITLE
feat: arc click scroll, hover/tap styles, animated numbers

### DIFF
--- a/src/components/CareerAttribute.tsx
+++ b/src/components/CareerAttribute.tsx
@@ -20,7 +20,7 @@ const CareerAttribute = ({ attribute, description }: CareerAttributeProps) => {
         <RatingSelect attributeParam={param} />
       </Flex>
       <Box>
-        <Heading as='h4' size='4' mb='2' id={toAttributeId(name)} tabIndex={-1}>
+        <Heading as='h4' size='4' mb='2' id={toAttributeId(name)}>
           {name}
         </Heading>
         <Text size='2' color='gray'>

--- a/src/lib/attributeId.ts
+++ b/src/lib/attributeId.ts
@@ -6,6 +6,15 @@ export const toAttributeId = (name: string): string =>
 
 export const scrollToAttribute = (name: string): void => {
   const el = document.getElementById(toAttributeId(name));
-  el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  el?.focus({ preventScroll: true });
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const description = el.nextElementSibling;
+  if (description) {
+    range.setEnd(description, description.childNodes.length);
+  }
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
 };


### PR DESCRIPTION
## Summary

- Clicking a chart arc smooth-scrolls to the corresponding attribute section and selects the heading + description text (using the Selection API instead of programmatic focus)
- Arc paths get brightness hover and tap feedback via `whileHover`/`whileTap`
- Arc number labels animate in with a scale pop on first appearance, slide to new position when the rating changes, and scale out on exit
- Numbers tween through whole-number increments (via `useMotionValue` + imperative `animate`) rather than jumping to the new value

## Test plan

- [ ] Click a chart arc — page scrolls to attribute, heading + description are highlighted
- [ ] Hover over an arc — brightness increases; move away — returns to base
- [ ] Click and hold an arc — dims while held, returns to base on release
- [ ] Set a rating for the first time — arc and number label both pop in with scale animation
- [ ] Change an existing rating — number tweens through whole numbers; label slides to new edge position; no scale re-animation
- [ ] Reset a rating — arc and label scale out
- [ ] Clicking an opportunity list item still scrolls and selects correctly
- [ ] `yarn check && yarn typecheck` pass