### PR TITLE
docs: add worktree requirements and src styling/accessibility guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,18 @@ When making code changes, you MUST proactively suggest updates to relevant docum
 
 Do not wait for the user to ask about documentation. Identify when your changes have made documentation stale and suggest specific updates.
 
+### Worktrees
+
+**REQUIRED**: All issue work MUST be done in a git worktree, not on the main working tree.
+
+Start a worktree session using Claude's built-in flag:
+
+```
+claude --worktree <issue-name>
+```
+
+This creates an isolated checkout at `.claude/worktrees/<issue-name>` on its own branch, so multiple issues can be worked in parallel without conflict. Claude will prompt to keep or clean up the worktree on exit.
+
 ### Git Workflow
 
 All commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/) syntax:

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -26,6 +26,14 @@ layout.tsx         — header, CareerSelect, reset dialog, GitHub link
 
 - `src/lib/attributeId.ts` — `toAttributeId(name)` converts an attribute name to a kebab-case element ID; used by `CareerAttribute`, `AltChart`, and `OpportunitiesCard` to connect scroll targets to headings
 
+## Styling
+
+This project uses Radix for component styling. There is almost never a scenario to use `style` props — use only what is available from Radix component props.
+
+## Accessibility
+
+This project uses Ariakit for accessibility. Evaluate all changes and additions against current accessibility guidelines. Always use semantically correct HTML tags.
+
 ## SSR Note
 
 `AltChart` uses `useState(false)` + `useEffect(() => setIsClient(true))` to defer rendering until after hydration. This avoids visx/SVG SSR mismatches. Do not remove this pattern without testing hydration.


### PR DESCRIPTION
## Summary

- Adds a `### Worktrees` section to root `CLAUDE.md` requiring all issue work to be done in a git worktree, with instructions on how to start one
- Adds `## Styling` and `## Accessibility` sections to `src/CLAUDE.md` documenting Radix and Ariakit usage guidelines