### PR TITLE
docs: add ADR process and write ADRs 003–006

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,18 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 2. Create files/directories relative to that root
 3. Run `git status` to confirm files are detected by git
 
+### Architecture Decision Records (ADRs)
+
+ADRs are stored in `docs/adr/` and follow the naming convention `NNN-descriptive-slug.md`.
+
+**Template** (Status / Context / Decision / Consequences). Status values: `Proposed`, `Accepted`, `Deprecated`, `Superseded by ADR-NNN`.
+
+**PR checklist — for every pull request:**
+
+- **New ADR?** — If the PR introduces a significant architectural decision (new dependency, data flow pattern, tooling change, performance trade-off), create an ADR.
+- **Existing ADRs followed?** — Verify the changes comply with accepted ADRs. If a change conflicts, either revise the ADR first or explicitly note the deviation.
+- **Revise an ADR?** — If the constraints that drove a previous decision have changed, revisiting it is valid. Update the ADR's status to `Superseded by ADR-NNN` and write the replacement.
+
 ### Technical Review Standards
 
 Always fully evaluate the technical merits of questions and suggestions against relevant sources of truth and documentation.

--- a/docs/adr/001-visx-alpha-channel.md
+++ b/docs/adr/001-visx-alpha-channel.md
@@ -26,16 +26,16 @@ We use the alpha channel release of `@visx/visx` (`4.0.1-alpha.0`) for the follo
 
 The following visx APIs are used in this project:
 
-- `@visx/event` — `localPoint`
-- `@visx/group` — `Group`
-- `@visx/point` — `Point`
-- `@visx/responsive` — `ScaleSVG`
-- `@visx/scale` — `scaleLinear`, `scaleBand`, `scaleRadial`
-- `@visx/shape` — `Line`, `LineRadial`, `Arc`
-- `@visx/text` — `Text`
-- `@visx/tooltip` — `TooltipWithBounds`, `useTooltip`, `defaultStyles`
+- `@visx/event` — `localPoint` (`RatingsChart.tsx`)
+- `@visx/group` — `Group` (`RatingsChart.tsx`)
+- `@visx/responsive` — `ScaleSVG` (`RatingsChart.tsx`)
+- `@visx/scale` — `scaleBand`, `scaleRadial` (`src/lib/chartGeometry.ts`)
+- `@visx/shape` — `Arc` (`RatingsChart.tsx`)
+- `@visx/tooltip` — `TooltipWithBounds`, `useTooltip`, `defaultStyles` (`RatingsChart.tsx`)
 
 None of these have API-level breaking changes between 3.x and 4.0.
+
+Note: `d3-shape` (`arc`) is also used directly in `src/lib/chartGeometry.ts` as an explicit dependency (see ADR 004). It was previously a transitive dependency of `@visx/visx` only.
 
 ## Consequences
 

--- a/docs/adr/003-path-based-url-state.md
+++ b/docs/adr/003-path-based-url-state.md
@@ -1,0 +1,34 @@
+# ADR 003: Path-Based URL State
+
+## Status
+
+Accepted
+
+## Context
+
+Career level and attribute ratings must be shareable via URL so users can link directly to a specific assessment. The initial implementation used `nuqs`, a library that syncs React state to URL query parameters.
+
+The `nuqs` approach introduced friction:
+
+- Query parameters produce URLs like `?c=1&e=2&...` — verbose and fragile when attribute keys change
+- `nuqs` required wrapping the app in a `NuqsAdapter` provider and added a third-party dependency for what is essentially a routing concern
+- Query parameters are not suited to a Next.js App Router architecture where dynamic segments are first-class
+
+## Decision
+
+State is encoded in the URL path, not query parameters:
+
+- `/` redirects to `/P1` (default level)
+- `/{level}` — level selected, no ratings set
+- `/{level}/{encoded}` — level with base-36 encoded ratings
+
+The encoding is handled by `src/lib/ratingsEncoding.ts` (pure encode/decode, no browser APIs). `RatingsProvider` initializes synchronously from the URL path via a lazy `useState` initializer — not `useEffect` — to avoid hydration mismatches. Updates use `window.history.replaceState` so ratings changes do not cause remounts or push history entries.
+
+`nuqs` has been removed entirely.
+
+## Consequences
+
+- URLs are short and human-readable (e.g., `/P3/3f5c1zhm`)
+- Path segments are valid Next.js dynamic segments, enabling file-based OG image routes (`[level]/[encoded]/opengraph-image.tsx`)
+- Encoding is a custom format; `src/lib/ratingsEncoding.ts` must be kept in sync with the attribute set in `data/`
+- Level navigation uses `router.push` (adds a history entry); rating changes use `replaceState` (no history entry) — this is intentional

--- a/docs/adr/004-server-safe-chart-geometry.md
+++ b/docs/adr/004-server-safe-chart-geometry.md
@@ -1,0 +1,33 @@
+# ADR 004: Server-Safe Chart Geometry Extraction
+
+## Status
+
+Accepted
+
+## Context
+
+The radial bar chart (`RatingsChart`) is a `'use client'` component that uses React hooks, Framer Motion, and Radix CSS variables (`var(--red-6)`). Adding OG image generation required rendering the same chart server-side via `next/og` (`ImageResponse` / Satori).
+
+Satori is a server-only JSX-to-image renderer with strict constraints:
+
+- Cannot execute React hooks
+- Cannot resolve CSS custom properties (`var(...)`)
+- Cannot run Framer Motion
+- Does not support `<text>` SVG elements
+
+A naive solution — copying the arc math into the OG image route — would duplicate the scale math and create a drift risk between the visual chart and OG images.
+
+## Decision
+
+All arc geometry math is extracted into `src/lib/chartGeometry.ts`, a pure module with no browser APIs, no React, and no CSS variable references.
+
+- `computeChartGeometry()` takes an array of `{ key, name, colorName, value }` and returns `ArcGeometry[]` with pre-computed start/end angles, radii, text positions, and SVG path strings
+- Resolved hex colors from `@radix-ui/colors` (JS import, not CSS) are stored on each `ArcGeometry` — no CSS vars needed in the OG context
+- `d3-shape` (`arc()`) is used directly for path generation; it is declared as an explicit dependency in `package.json` (previously transitive via `@visx/visx`)
+- `RatingsChart` and the OG image route (`opengraph-image.tsx`) both import from `chartGeometry.ts` — one shared source of truth
+
+## Consequences
+
+- The interactive chart and OG images are guaranteed to use identical arc positions and proportions
+- `chartGeometry.ts` must remain side-effect-free and import-safe from server routes — do not add browser APIs, React hooks, or CSS imports to it
+- Arc ordering in `buildArcs()` (`src/lib/ogChart.tsx`) must match the ordering that `RatingsChart` produces via `Object.groupBy(themeGroups)`; this constraint is documented in both files

--- a/docs/adr/005-radix-ui-themes.md
+++ b/docs/adr/005-radix-ui-themes.md
@@ -1,0 +1,35 @@
+# ADR 005: Radix UI Themes for Styling
+
+## Status
+
+Accepted
+
+## Context
+
+The project needed a component and styling system that provides:
+
+- Accessible interactive components (dropdowns, buttons, tooltips) without building them from scratch
+- A consistent design token system (spacing, color, radius, typography) without a custom design system
+- Dark mode support with minimal boilerplate
+- Compatibility with React 19 and Next.js App Router
+
+Alternatives considered:
+
+- **Tailwind CSS** — utility-first, widely adopted, but requires a separate accessible component library (Headless UI, Radix primitives) and custom design token setup
+- **Plain CSS / CSS Modules** — maximum control, but accessibility and design consistency burden falls entirely on the project
+- **shadcn/ui** — Radix primitives + Tailwind; the Tailwind dependency adds complexity without benefit at this project's scale
+
+## Decision
+
+We use Radix UI Themes (`@radix-ui/themes`) as the primary styling system:
+
+- **Component props** are used for all layout and styling (`m`, `p`, `color`, `size`, etc.) — `style` props are not used in application code
+- Radix's built-in dark theme is applied globally (`appearance='dark'`)
+- `@radix-ui/colors` is imported directly in `src/lib/chartGeometry.ts` to resolve theme colors to hex for server-side OG image rendering (where CSS variables are unavailable)
+- SCSS (`src/app/global.scss`) handles only layout concerns that fall outside Radix's prop system
+
+## Consequences
+
+- Radix component API changes are a migration concern; pin the major version in `package.json`
+- The Satori constraint (OG image rendering cannot use CSS vars) means any new colors used in OG layouts must be sourced from `@radix-ui/colors` directly, not from CSS custom properties
+- `style` props should remain absent from application components; reaching for a `style` prop is a signal to look for the equivalent Radix prop first

--- a/docs/adr/006-csv-source-of-truth.md
+++ b/docs/adr/006-csv-source-of-truth.md
@@ -1,0 +1,39 @@
+# ADR 006: CSV as Data Source of Truth with Generated JSON
+
+## Status
+
+Accepted
+
+## Context
+
+The application displays career competency data: attributes, theme groupings, and per-level descriptions for both IC and EM tracks. This data changes occasionally as the career ladder evolves.
+
+Two formats are required:
+- A human-editable format for maintaining the data
+- A machine-readable format with TypeScript types for the application
+
+Storing data directly as JSON creates friction: JSON is error-prone to edit manually, has no column-alignment affordances, and requires hand-editing TypeScript type files when the shape changes.
+
+Storing data as TypeScript or a database adds engineering overhead disproportionate to the project's scale.
+
+## Decision
+
+CSV files in `data/` are the source of truth:
+
+- `data/ic.csv` — IC track level definitions
+- `data/em.csv` — EM track level definitions
+
+JSON files are generated from CSVs using `mlr` (Miller):
+
+- `yarn ic` → `data/ic.json`
+- `yarn em` → `data/em.json`
+- `yarn data-types` → TypeScript type declarations from JSON
+
+The application imports only the generated JSON/types. **Edits to `data/*.json` or `data/*.d.ts` directly are incorrect** — they will be overwritten on the next generation run. See `data/CLAUDE.md` for details.
+
+## Consequences
+
+- Contributors must run generation scripts after editing CSVs; forgetting produces a stale/inconsistent application
+- `mlr` must be installed locally to regenerate data (see README for setup)
+- TypeScript types for data shapes are always derived from the actual data, eliminating manual type maintenance
+- Adding or renaming attributes requires updating both the CSV and verifying that `src/lib/ratingsEncoding.ts` encoding still covers all attribute `param` values correctly


### PR DESCRIPTION
## Summary

- Adds an **Architecture Decision Records** section to root `CLAUDE.md` with the ADR location, template, and a PR checklist (evaluate if new ADR is warranted, verify compliance with existing ADRs, guidance on superseding an ADR when constraints change)
- Revises **ADR 001** to reflect the post-refactor visx API surface (removes `@visx/point`, `@visx/text`, `scaleLinear`, `Line`, `LineRadial`; notes `d3-shape` is now a direct dep)
- Adds four new ADRs documenting significant decisions that were undocumented:
  - **ADR 003** — Path-based URL state (replaced `nuqs`)
  - **ADR 004** — Server-safe chart geometry extraction (`chartGeometry.ts` shared between client chart and OG image route)
  - **ADR 005** — Radix UI Themes for styling (rationale, "no `style` props" constraint, Satori intersection)
  - **ADR 006** — CSV as data source of truth with generated JSON

## ADR checklist

- No new architectural decisions introduced by this PR itself — it is documentation only.
- Existing ADRs: ADR 001 revised to match current code; no other ADRs affected.