### PR TITLE
fix(a11y): add accessible names to icon buttons and select triggers

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,7 +51,7 @@ export default function RootLayout({
                   <Flex ml='auto' gap='2'>
                     <HeaderControls />
                     <Tooltip content='GitHub'>
-                      <IconButton variant='surface' asChild>
+                      <IconButton variant='surface' asChild aria-label='GitHub'>
                         <a href='https://github.com/brianespinosa/career'>
                           <GitHubLogoIcon />
                         </a>

--- a/src/components/CareerAttribute.tsx
+++ b/src/components/CareerAttribute.tsx
@@ -17,7 +17,10 @@ const CareerAttribute = ({ attribute, description }: CareerAttributeProps) => {
   return (
     <Flex gap='4' py='3' align='center' justify='start'>
       <Flex minWidth='7rem' justify='center'>
-        <RatingSelect attributeParam={param} />
+        <RatingSelect
+          attributeParam={param}
+          attributeId={toAttributeId(name)}
+        />
       </Flex>
       <Box>
         <Heading as='h4' size='4' mb='2' id={toAttributeId(name)}>

--- a/src/components/CareerSelect.tsx
+++ b/src/components/CareerSelect.tsx
@@ -26,7 +26,7 @@ const CareerSelect = () => {
       value={career}
       onValueChange={(v) => setCareer(v as LevelKeys)}
     >
-      <Select.Trigger variant='soft'>
+      <Select.Trigger variant='soft' aria-label='Career level'>
         {getLabel(selectedLevelObj)}
       </Select.Trigger>
       <Select.Content position='popper'>

--- a/src/components/RatingSelect.tsx
+++ b/src/components/RatingSelect.tsx
@@ -5,9 +5,10 @@ import useRatingParam, { type RatingKey } from '@/hooks/useRatingParam';
 
 interface RatingSelectProps {
   attributeParam: string;
+  attributeId: string;
 }
 
-const RatingSelect = ({ attributeParam }: RatingSelectProps) => {
+const RatingSelect = ({ attributeParam, attributeId }: RatingSelectProps) => {
   const [rating, setRating, RATINGS] = useRatingParam(attributeParam);
 
   return (
@@ -19,6 +20,7 @@ const RatingSelect = ({ attributeParam }: RatingSelectProps) => {
       <Select.Trigger
         placeholder='Pick one'
         variant={rating ? 'soft' : 'surface'}
+        aria-labelledby={attributeId}
       >
         {(rating && RATINGS[rating]) ?? 'Pick one'}
       </Select.Trigger>

--- a/src/components/ResetButton.tsx
+++ b/src/components/ResetButton.tsx
@@ -27,7 +27,7 @@ export default function ResetButton(): React.ReactNode {
     <AlertDialog.Root>
       <Tooltip content='Reset'>
         <AlertDialog.Trigger>
-          <IconButton variant='surface'>
+          <IconButton variant='surface' aria-label='Reset'>
             <ResetIcon />
           </IconButton>
         </AlertDialog.Trigger>


### PR DESCRIPTION
Closes #25

## Summary

- Add `aria-label="Career level"` to `CareerSelect` trigger
- Add `aria-labelledby` to `RatingSelect` trigger, linked to the attribute heading via `attributeId` prop
- Add `aria-label="Reset"` to the reset `IconButton`
- Add `aria-label="GitHub"` to the GitHub `IconButton`

## Changes

- `src/components/CareerSelect.tsx` — `aria-label="Career level"` on `Select.Trigger`
- `src/components/RatingSelect.tsx` — new `attributeId` prop; `aria-labelledby={attributeId}` on `Select.Trigger`
- `src/components/CareerAttribute.tsx` — passes `attributeId={toAttributeId(name)}` to `RatingSelect`
- `src/components/ResetButton.tsx` — `aria-label="Reset"` on `IconButton`
- `src/app/layout.tsx` — `aria-label="GitHub"` on `IconButton`

## Testing

- `yarn build` passes with no TypeScript errors
- Run Lighthouse accessibility audit or axe DevTools — no "Buttons do not have an accessible name" or "Links do not have an accessible name" failures
- Visually unchanged