### PR TITLE
test: fail on unexpected console.warn/error in unit tests

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,18 @@
 import '@testing-library/jest-dom';
+import { afterEach, beforeEach, vi } from 'vitest';
+
+// Fail tests on unexpected console.warn/error. Tests that intentionally trigger
+// these (e.g. testing an error branch) must mock console.error/warn explicitly
+// within that test, which overrides this global mock for that call.
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation((...args) => {
+    throw new Error(`Unexpected console.warn: ${args.join(' ')}`);
+  });
+  vi.spyOn(console, 'error').mockImplementation((...args) => {
+    throw new Error(`Unexpected console.error: ${args.join(' ')}`);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});


### PR DESCRIPTION
## Summary

- `vitest.setup.ts`: installs a throwing mock on `console.warn` and `console.error` in `beforeEach` so any unexpected warning or error fails the test immediately
- `afterEach` calls `vi.restoreAllMocks()` to clean up between tests
- Tests that intentionally verify a warning (e.g. unknown colorName in `chartGeometry`, error-path tests in `RatingsProvider`) already mock `console.error` explicitly within the test, overriding the global mock for that call only

## Test plan

- [x] All 64 existing tests pass with the new setup — no unexpected warnings were silently passing before