### PR TITLE
chore(deps): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,19 @@
 version: 2
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    rebase-strategy: auto
+    commit-message:
+      prefix: chore
+      include: scope
+
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: daily
+    rebase-strategy: auto
     target-branch: main
     commit-message:
       prefix: chore


### PR DESCRIPTION
## Summary

- Change npm update schedule from weekly to daily
- Add `rebase-strategy: auto` to npm ecosystem so open PRs are rebased when base branch changes
- Add `github-actions` ecosystem with the same daily schedule and rebase strategy

## Test plan

- [ ] Verify Dependabot PRs for both npm and GitHub Actions appear after enabling
- [ ] Verify open Dependabot PRs auto-rebase when new commits land on `main`