### PR TITLE
chore: add probot/settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,8 @@
+_extends: brianespinosa/settings:nextjs.yml
+
+repository:
+  name: career
+  description: A self-assessment tool for engineers to rate themselves against the attributes of their target career level, identify their highest-impact growth opportunities, and generate SMART goals with an LLM.
+  homepage: https://career.bje.co
+  topics: nextjs, react, typescript
+  private: false


### PR DESCRIPTION
## Summary

- Adds `.github/settings.yml` extending `brianespinosa/settings:nextjs.yml`
- Populates `repository:` block with current GitHub metadata

## Why

Enrolls this repo in centralized settings management via the probot/settings app, ensuring branch protection, merge strategy, and labels stay in sync with the shared configuration.