### PR TITLE
ci(hooks): add SessionStart hook for corepack and yarn install

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (cloud) environments
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Enable corepack so the packageManager field in package.json is honored
+corepack enable
+
+# Install dependencies
+cd "$CLAUDE_PROJECT_DIR"
+yarn install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(gh issue:*)",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,7 @@ pre-commit:
   commands:
     biome:
       glob: "*.{js,jsx,ts,tsx,json,css,scss,sass}"
+      exclude: ".claude/**"
       run: yarn biome check --write {staged_files}
       stage_fixed: true
     sort-package-json:


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook that enables corepack and runs `yarn install` in cloud environments on every session start
- Registers the hook in `.claude/settings.json`
- Excludes `.claude/` from the lefthook biome glob to match the existing `biome.json` exclusion

## Test plan
- [x] Hook executes successfully (`yarn install` completes with no warnings)
- [x] Linter passes (`yarn check`)
- [x] All 112 tests pass (`yarn test`)
- [x] Pre-commit hooks pass

https://claude.ai/code/session_01DqGQh8Nf6QrQ5TP9HsAJWZ