### PR TITLE
ci(dependabot): approve PR before enabling auto-merge

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -42,7 +42,7 @@ Monitors `npm` dependencies weekly, targeting `main`. Commit messages use `chore
 
 Config: `.github/workflows/dependabot-auto-merge.yml`
 
-Triggers on `pull_request_target` (runs in base branch context so `GITHUB_TOKEN` has full permissions). Checks `github.actor == 'dependabot[bot]'` and enables auto-merge via squash. `pull_request_target` is safe here because no PR code is checked out or executed.
+Triggers on `pull_request_target` (runs in base branch context so `GITHUB_TOKEN` has full permissions). Checks `github.actor == 'dependabot[bot]'`, approves the PR, then enables auto-merge via squash. The approve step is required when branch protection requires a review before merge; `GITHUB_TOKEN` can approve PRs it did not author, and Dependabot PRs are authored by `dependabot[bot]`. `pull_request_target` is safe here because no PR code is checked out or executed.
 
 ## E2E Coverage Policy
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary

- Adds a \`gh pr review --approve\` step to the dependabot-auto-merge workflow, run before \`gh pr merge --auto --squash\`.
- Branch protection requires an approving review before merge, so the auto-merge step alone is not sufficient; PRs sit waiting for a human approval.
- \`GITHUB_TOKEN\` can approve PRs it did not author, and Dependabot PRs are authored by \`dependabot[bot]\`, so the workflow's own token is allowed to approve them.
- Updates \`.github/CLAUDE.md\` to describe the new step.

## Test plan

- [ ] Next Dependabot PR is approved by \`github-actions[bot]\` and auto-merges once required checks pass.