### PR TITLE
ci(dependabot): use GitHub App token for approve and merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,11 +10,16 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.THUMBS_UP_CLIENT_ID }}
+          private-key: ${{ secrets.THUMBS_UP_PK }}
       - run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- The default \`GITHUB_TOKEN\` cannot approve PRs opened by \`dependabot[bot]\` (see [failed run](https://github.com/brianespinosa/career/actions/runs/26420571568/job/77774301270?pr=226)).
- Mint an installation token with [\`actions/create-github-app-token@v3\`](https://github.com/actions/create-github-app-token) using the new \`THUMBS_UP_CLIENT_ID\` and \`THUMBS_UP_PK\` Dependabot secrets.
- Use the app token for both the \`gh pr review --approve\` and \`gh pr merge --auto --squash\` steps so the approval is attributed to the app, not the workflow's own token.

\`v3\` is the first major version that accepts \`client-id\` (\`app-id\` is deprecated).

## Test plan

- [ ] Next Dependabot PR auto-approves and enables auto-merge without the previous "Bad credentials"/self-approval failure.