### PR TITLE
fix(deps): resolve 11 Dependabot alerts for undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,16 @@
   },
   "resolutions": {
     "@vercel/backends/srvx": "^0.11.13",
+    "@vercel/blob/undici": ">=7.28.0 <8",
     "@vercel/fastify/@tootallnate/once": "^3.0.1",
     "@vercel/fun/@tootallnate/once": "^3.0.1",
     "@vercel/fun/tar": ">=7.5.11",
-    "@vercel/node/undici": "^6.24.0",
+    "@vercel/node/undici": ">=7.28.0 <8",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
     "@vercel/python-analysis/minimatch": "^10.2.3",
-    "sass/immutable": ">=5.1.8 <6"
+    "@vercel/sandbox/undici": ">=7.28.0 <8",
+    "sass/immutable": ">=5.1.8 <6",
+    "vercel/undici": ">=7.28.0 <8"
   },
   "dependencies": {
     "@radix-ui/colors": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,13 +831,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fastify/busboy@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@fastify/busboy@npm:2.1.1"
-  checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
-  languageName: node
-  linkType: hard
-
 "@floating-ui/core@npm:^1.7.5":
   version: 1.7.5
   resolution: "@floating-ui/core@npm:1.7.5"
@@ -9643,26 +9636,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:5.29.0":
-  version: 5.29.0
-  resolution: "undici@npm:5.29.0"
-  dependencies:
-    "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10c0/e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
-  languageName: node
-  linkType: hard
-
-"undici@npm:^6.23.0, undici@npm:^6.24.0":
-  version: 6.24.1
-  resolution: "undici@npm:6.24.1"
-  checksum: 10c0/53fdbaa357139a2c12deed34f67d67fc6ad269630ba85a1507e7717f53ad2d3a02c95fbd17d3ab321e34c60b6f0a716cdc2f7e2eca1e07178702dc89cc3a73c4
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.27.1":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+"undici@npm:>=7.28.0 <8":
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 11 Dependabot alerts for `undici` by adding scoped `resolutions` overrides for its parents (`vercel`, `@vercel/blob`, `@vercel/node`, `@vercel/sandbox`)
- Target version: >=7.28.0
- Resolved version: 7.29.0

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#69](https://github.com/brianespinosa/career/security/dependabot/69) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#68](https://github.com/brianespinosa/career/security/dependabot/68) | CVE-2026-11525 | low | 15.0% | Set-Cookie SameSite attribute downgrade via permissive substring matching |
| [#67](https://github.com/brianespinosa/career/security/dependabot/67) | CVE-2026-9679 | medium | 16.8% | HTTP header injection via Set-Cookie percent-decoding |
| [#66](https://github.com/brianespinosa/career/security/dependabot/66) | CVE-2026-9679 | medium | 16.8% | HTTP header injection via Set-Cookie percent-decoding |
| [#63](https://github.com/brianespinosa/career/security/dependabot/63) | CVE-2026-6734 | high | 27.0% | Cross-origin request routing via SOCKS5 proxy pool reuse |
| [#62](https://github.com/brianespinosa/career/security/dependabot/62) | CVE-2026-6733 | low | 12.5% | HTTP response queue poisoning via keep-alive socket reuse |
| [#61](https://github.com/brianespinosa/career/security/dependabot/61) | CVE-2026-6733 | low | 12.5% | HTTP response queue poisoning via keep-alive socket reuse |
| [#60](https://github.com/brianespinosa/career/security/dependabot/60) | CVE-2026-9697 | high | 37.3% | TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent |
| [#59](https://github.com/brianespinosa/career/security/dependabot/59) | CVE-2026-9678 | medium | 28.5% | Cross-user information disclosure via shared cache whitespace bypass |
| [#24](https://github.com/brianespinosa/career/security/dependabot/24) | CVE-2026-1527 | medium | 16.7% | CRLF Injection via `upgrade` option |
| [#22](https://github.com/brianespinosa/career/security/dependabot/22) | CVE-2026-1525 | medium | 39.5% | HTTP Request/Response Smuggling issue |

## Merge risk: Medium (6/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 2 | 5.29.0 -> 7.29.0 (major) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of undici (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

EPSS (above) reflects exploitation urgency per alert; merge risk (this table) reflects how risky this specific fix is to merge. These are independent signals, not combined into one score.

## Dependency chain

```
├─ @vercel/blob@npm:2.4.0
│  └─ undici@npm:6.24.1 (via npm:^6.23.0)
│
├─ @vercel/node@npm:5.8.26
│  └─ undici@npm:6.24.1 (via npm:^6.24.0)
│
├─ @vercel/sandbox@npm:2.4.0
│  └─ undici@npm:7.27.2 (via npm:^7.27.1)
│
├─ vercel@npm:56.5.0
│  └─ undici@npm:5.29.0 (via npm:5.29.0)
│
└─ vercel@npm:56.5.0 [4d903]
   └─ undici@npm:5.29.0 (via npm:5.29.0)
```

## Changes

```json
"resolutions": {
  "@vercel/blob/undici": ">=7.28.0 <8",
  "@vercel/node/undici": ">=7.28.0 <8",
  "@vercel/sandbox/undici": ">=7.28.0 <8",
  "vercel/undici": ">=7.28.0 <8"
}
```

## Verification

- [x] Lockfile validated: 1 resolved version (7.29.0) satisfies `>=7.28.0 <8` (previously 3 distinct versions: 5.29.0, 6.24.1, 7.27.2)
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (19 files, 121 tests)
- [x] `yarn build` passes (`next build`)
- [x] `yarn check` passes (biome; only pre-existing config schema-version info notices, no fixes applied)
- [ ] `yarn knip` fails identically on `main` (`PLAYWRIGHT_BASE_URL is not set`) - pre-existing, unrelated to this change; confirmed by running the same command against `origin/main` in a separate worktree
- Skipped: `yarn e2e` (requires a deployed Vercel preview URL; CI is the signal), `yarn data-types` (references `./json-d-ts.sh`, which does not exist in the repo on either branch - pre-existing, unrelated), `yarn em`/`yarn em-ml`/`yarn ic`/`yarn ic-ml` (CSV-to-JSON data pipeline scripts, not checks)

## References

- https://github.com/brianespinosa/career/security/dependabot/69
- https://github.com/brianespinosa/career/security/dependabot/68
- https://github.com/brianespinosa/career/security/dependabot/67
- https://github.com/brianespinosa/career/security/dependabot/66
- https://github.com/brianespinosa/career/security/dependabot/63
- https://github.com/brianespinosa/career/security/dependabot/62
- https://github.com/brianespinosa/career/security/dependabot/61
- https://github.com/brianespinosa/career/security/dependabot/60
- https://github.com/brianespinosa/career/security/dependabot/59
- https://github.com/brianespinosa/career/security/dependabot/24
- https://github.com/brianespinosa/career/security/dependabot/22
