### PR TITLE
fix(e2e): replace import-time PLAYWRIGHT_BASE_URL throw with localhost fallback

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -10,6 +10,12 @@ Set environment variables before running:
 - `PLAYWRIGHT_BASE_URL` — the target URL (e.g., a Vercel preview deployment URL)
 - `VERCEL_BYPASS_SECRET` — Vercel protection bypass token
 
+These variables are required for tests to pass, not for the config to load. When
+`PLAYWRIGHT_BASE_URL` is unset, `playwright.config.ts` falls back to
+`http://localhost:3000` so config-loading tools (e.g. knip) work without it;
+running the tests without a deployed URL fails at test time with connection
+errors. Never set a fabricated `PLAYWRIGHT_BASE_URL` to satisfy tooling.
+
 ## Selector Strategy
 
 **Prefer `getByRole` and other accessible locators. Never use `data-testid` or other test-only attributes.**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL;
-if (!baseURL) {
-  throw new Error(
-    'PLAYWRIGHT_BASE_URL is not set. Set it to a Vercel preview deployment URL. See e2e/CLAUDE.md.',
-  );
-}
-
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
   retries: process.env.CI ? 1 : 0,
   reporter: [['html', { open: 'never' }]],
   use: {
-    baseURL,
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000',
     extraHTTPHeaders: {
       'x-vercel-protection-bypass': process.env.VERCEL_BYPASS_SECRET ?? '',
     },


### PR DESCRIPTION
## Changes

- `playwright.config.ts`: remove the import-time throw when `PLAYWRIGHT_BASE_URL` is unset; default `baseURL` to `process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000'` per the standardized Playwright setup
- `e2e/CLAUDE.md`: document that the env vars are required for tests to pass, not for the config to load, and that tooling must not fabricate a `PLAYWRIGHT_BASE_URL` value

## Why

The throw broke every tool that merely loads the config. `yarn knip` failed in any environment without the variable, and the error copy invited agents to inject a dummy URL just to get tooling to run. Running e2e without a deployed URL now fails at test time with connection errors instead.

## Testing

- `yarn knip` succeeds with `PLAYWRIGHT_BASE_URL` unset (previously threw); configuration hints are pre-existing on `main`
- `yarn typecheck` and `yarn check` pass
- Pre-commit hooks (biome, test, typecheck) passed on commit

Closes #332