### PR TITLE
fix(deps): resolve 2 Dependabot alerts for immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@vercel/fun/tar": ">=7.5.11",
     "@vercel/node/undici": "^6.24.0",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
-    "@vercel/python-analysis/minimatch": "^10.2.3"
+    "@vercel/python-analysis/minimatch": "^10.2.3",
+    "sass/immutable": ">=5.1.8 <6"
   },
   "dependencies": {
     "@radix-ui/colors": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6975,10 +6975,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
+"immutable@npm:>=5.1.8 <6":
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10c0/ae7032b60b81b682f3e7e4df13e1ec9a401a603eb81b15bb3e37331ed6666e318c71994c6936e1462eb443d32d04769396562a7e2669da22457c8ba279c03ad2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 2 Dependabot alert(s) for `immutable` by adding a scoped override (transitive dependency of `sass`)
- Target version: >=5.1.8
- Resolved version: 5.1.9

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#79](https://github.com/brianespinosa/career/security/dependabot/79) | CVE-2026-59880 | high | 35.3% | Hash-collision algorithmic complexity denial of service in Immutable.Map/Set |
| [#78](https://github.com/brianespinosa/career/security/dependabot/78) | CVE-2026-59879 | high | 35.8% | Immutable.js `List` 32-bit trie overflow -> unrecoverable DoS |

## Merge risk: Medium (4/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 0 | 5.1.5 -> 5.1.9 (patch) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of immutable (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
└─ sass@npm:1.101.7
   └─ immutable@npm:5.1.5 (via npm:^5.1.5)
```

## Changes

```json
"resolutions": {
  "sass/immutable": ">=5.1.8 <6"
}
```

## Verification

- [x] Lockfile validated: 1 resolved version satisfies `>=5.1.8 <6` (5.1.5 -> 5.1.9)
- [x] `yarn build` passes (Next.js production build, exercises `sass` SCSS compilation via `src/app/global.scss`)
- [x] `yarn check` passes (Biome; pre-existing config-version info messages unrelated to this change)
- [x] `yarn knip` passes (only pre-existing configuration hints, no errors)
- [x] `yarn test` passes (121 tests, 19 files)
- [x] `yarn typecheck` passes (`tsc --noEmit`)
- [ ] `yarn e2e` skipped: Playwright's `chromium_headless_shell` browser binary is not installed in this environment (`browserType.launch: Executable doesn't exist`); requires `playwright install`, which is a machine-level install this flow does not perform. CI is the signal.
- [ ] `yarn data-types` skipped: the referenced script `./json-d-ts.sh` does not exist anywhere in the repository (pre-existing, unrelated to this change) and fails to start.
- [ ] `yarn em`, `yarn em-ml`, `yarn ic`, `yarn ic-ml` skipped: these are CSV-to-JSON data generation scripts (`mlr`) unrelated to code verification, and the `mlr` binary is not installed in this environment.

## References

- https://github.com/brianespinosa/career/security/dependabot/79
- https://github.com/brianespinosa/career/security/dependabot/78