### PR TITLE
docs: remove attribution guidance in favor of settings config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "github"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,13 +74,9 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 
 - Keep messages brief and easy to parse - avoid lengthy descriptions
 - Focus on specific, scannable details that help humans quickly identify what a commit contains
-- **NEVER** add "🤖 Generated with Claude Code" or similar footers to commit messages
-- **NEVER** add "Co-Authored-By: Claude" or any co-author footers to commits
 
 **Pull request requirements:**
 
-- **NEVER** add "Co-Authored-By: Claude" or any co-author attribution to PR descriptions
-- **NEVER** add "🤖 Generated with Claude Code" or similar attribution to PRs
 - Keep PR descriptions focused on technical changes, testing, and references
 
 ### File Operations and Repository Root


### PR DESCRIPTION
Replaces the `CLAUDE.md` prose forbidding `Co-Authored-By: Claude` and "Generated with Claude Code" footers with configuration that enforces it directly.

## Changes

- **`.claude/settings.json`** — adds the `attribution` property. Empty strings suppress the attribution text at the harness level:

  ```json
  "attribution": {
    "commit": "",
    "pr": ""
  }
  ```

- **`CLAUDE.md`** — removes the four `NEVER add ...` bullets, now redundant.

The non-attribution bullet in the same section is retained: `Keep PR descriptions focused on technical changes, testing, and references`.

## Why project settings and not just user settings

The `attribution` property is also set in my user-level `~/.claude/settings.json`, which would be sufficient for a single contributor. Committing it here instead means the behavior holds for any future outside contributor who does not have it configured on their own machine — which prose could enforce and a user-level setting cannot.

Added as the first key to keep the top-level ordering alphabetical.

## Testing

Documentation and configuration only, no code paths touched. `.claude/settings.json` validated as JSON. Pre-commit hooks ran and passed.