### PR TITLE
fix(deps): resolve Dependabot alerts for js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@vercel/fun/tar": ">=7.5.11",
     "@vercel/node/undici": ">=7.28.0 <8",
     "@vercel/prepare-flags-definitions/minimatch": "^10.2.3",
+    "@vercel/python-analysis/js-yaml": ">=4.3.1 <5",
     "@vercel/python-analysis/minimatch": "^10.2.3",
     "@vercel/sandbox/undici": ">=7.28.0 <8",
     "sass/immutable": ">=5.1.8 <6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7207,14 +7207,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:>=4.3.1 <5":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolves 3 Dependabot alert(s) for `js-yaml` by adding a scoped override
- Target version: >=4.3.1
- Resolved version: 4.3.1

## Alerts resolved

| # | CVE | Severity | EPSS | Summary |
|---|---|---|---|---|
| [#93](https://github.com/brianespinosa/career/security/dependabot/93) | GHSA-5p4m-2wfm-xmqj | high | 0% | Quadratic CPU consumption in !!omap resolution (3.x and 4.x) |
| [#73](https://github.com/brianespinosa/career/security/dependabot/73) | CVE-2026-59869 | high | 34.7% | YAML merge-key chains can force quadratic CPU consumption |
| [#70](https://github.com/brianespinosa/career/security/dependabot/70) | CVE-2026-53550 | medium | 30.5% | Quadratic-complexity DoS in merge key handling via repeated aliases |

## Merge risk: Medium (5/10)

| Factor | Score | Evidence |
|---|---|---|
| Version delta | 1 | 4.1.1 -> 4.3.1 (minor) |
| Runtime exposure | 1 | transitive under a runtime dependency |
| Usage surface | 0 | no source imports found for parents of js-yaml (build or tooling only) |
| Test signal | 1 | tests pass; affected modules not clearly exercised |
| Verification | 2 | one or more scripts skipped or partially run |

## Dependency chain

```
└─ @vercel/python-analysis@npm:0.13.1
   └─ js-yaml@npm:4.1.1 (via npm:4.1.1)
```

## Changes

```json
"@vercel/python-analysis/js-yaml": ">=4.3.1 <5"
```

## Verification

- [x] Lockfile validated: 1 resolved version satisfies `>=4.3.1 <5`
- [x] `yarn typecheck` passes
- [x] `yarn test` passes (121 tests, 19 files)
- [x] `yarn check` passes (biome; pre-existing unrelated schema-version info messages)
- [x] `yarn knip` passes (pre-existing unrelated config hints only)
- [x] `yarn build` passes (production build succeeds)
- [ ] `yarn data-types` skipped — `json-d-ts.sh` is referenced in `package.json` but does not exist in the repository (pre-existing, confirmed absent from `git ls-files`; unrelated to this change)
- [ ] `yarn e2e` skipped — requires a running/deployed server at `http://localhost:3000`; not available in this environment. CI is the verifier.
- `yarn em`, `yarn em-ml`, `yarn ic`, `yarn ic-ml` are CSV-to-JSON data pipeline scripts, not verification checks, and were not run.

## References

- https://github.com/brianespinosa/career/security/dependabot/93
- https://github.com/brianespinosa/career/security/dependabot/73
- https://github.com/brianespinosa/career/security/dependabot/70